### PR TITLE
Upgrade dependencies in PyPI publishing workflow

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -13,15 +13,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install setuptools wheel twine
+        python -m pip install --upgrade pip setuptools wheel twine
     - name: Build and publish
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}


### PR DESCRIPTION
`actions/checkout@v2` and `actions/setup-python@v2` have been deprecated for a while. Upgrading it to latest versions.

We can also ensure latest version of `setuptools`, `wheel`, and `twine` to be installed in the `Install dependencies` step.