### PR TITLE
Remove pkg_resources from html.py

### DIFF
--- a/tracerite/html.py
+++ b/tracerite/html.py
@@ -1,9 +1,10 @@
-import pkg_resources
 from html5tagger import E
 
 from .trace import extract_chain
 
-style = pkg_resources.resource_string(__name__, "style.css").decode()
+from importlib.resources import files
+
+style = files(__package__).joinpath("style.css").read_text(encoding="UTF-8")
 
 detail_show = "{display: inherit}"
 


### PR DESCRIPTION
This changeset resolves the ModuleNotFound error on our CI systems; it's the same as proposed by @zbynekwinkler in a comment on https://github.com/sanic-org/tracerite/pull/10/files