### PR TITLE
fix(inspector): Add parens around multiple exceptions

### DIFF
--- a/tracerite/inspector.py
+++ b/tracerite/inspector.py
@@ -116,7 +116,7 @@ def prettyvalue(val):
     try:
         floaty = isinstance(val, float) or "float" in str(val.dtype)
         if floaty: ret = f"{val:.2g}"
-    except AttributeError, TypeError:
+    except (AttributeError, TypeError):
         floaty = False
 
     if floaty: pass


### PR DESCRIPTION
This MR updates exception handling syntax to be compatible with Python 3.11+, where multiple exception types must be enclosed in parentheses. The previous use of except A, B: raised a SyntaxError under newer interpreters.

This fix issue: https://github.com/sanic-org/tracerite/issues/20